### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ successfully committed:
 - on Django < 1.9, use `django-transaction-hooks`_
 
 .. _on_commit: https://docs.djangoproject.com/en/stable/topics/db/transactions/#django.db.transaction.on_commit
-.. _django-transaction-hooks: https://django-transaction-hooks.readthedocs.org/
+.. _django-transaction-hooks: https://django-transaction-hooks.readthedocs.io/
 
 Why?
 ====


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
